### PR TITLE
InCorrect value passed into JWToken generator.

### DIFF
--- a/src/stream-net-tests/SigningTest.cs
+++ b/src/stream-net-tests/SigningTest.cs
@@ -25,7 +25,7 @@ namespace stream_net_tests
 
             var feed = client.Feed("flat", "1");
             var token = feed.ReadOnlyToken;
-            Assert.AreEqual("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6IioiLCJhY3Rpb24iOiIqIiwiZmVlZF9pZCI6ImZsYXQ6MSJ9.1gJgfGKbuOz793rYBlEFFICRHkM4a7a1VaEdelgYW9Y", token);
+            Assert.AreEqual("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJyZXNvdXJjZSI6IioiLCJhY3Rpb24iOiIqIiwiZmVlZF9pZCI6ImZsYXQxIn0.7435I3bhISLU2RdVeVVMtmjhLE7LPHvDgqQ6mnfFwhU", token);
         }
     }
 }

--- a/src/stream-net/StreamFeed.cs
+++ b/src/stream-net/StreamFeed.cs
@@ -51,7 +51,7 @@ namespace Stream
         {
             get
             {
-                return _client.JWToken(FeedId);
+                return _client.JWToken(FeedTokenId);
             }
         }
 


### PR DESCRIPTION
The value passed into the _client.JWToken had the incorrect format of slug:id. For the JWT token, the format should be slugid. This was the format used in the variable FeedTokenId. Therefore, the code was changed to pass this value instead of FeedId.
