### PR TITLE
Bug/issue#13/invalid app veyor install command

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,6 @@ version: 1.2.{build}
 environment:
   COVERALLS_REPO_TOKEN: 
     secure: Gi55/aHqrZs6SjL0DCGl9jVTQLapvcroI21SLtMZ/7npQIwzoRrx1zA+sP+0O7jj
-install:
-- cmd: >-
-    set NUNIT3_HOME=C:\Tools\NUnit3
-
-    appveyor DownloadFile https://github.com/nunit/nunit/releases/download/3.0.0-beta-3/nunit-3.0.0-beta-3.zip
-
-    7z x -o%NUNIT3_HOME% nunit-3.0.0-beta-3.zip > NUL
-
-    set PATH=%NUNIT3_HOME%\bin;%PATH%
 before_build:
 - cmd: nuget restore .\src\stream-net.sln
 build:


### PR DESCRIPTION
This fixes Issue #13 
Initially AppVeyor did not support NUnit3.0, as a result the appVeyor.yml file included a installation step which downloads NUnit 3.0 beta and adds it to the system path. This step is now invalid as AppVeyor has updated their service to use NUnit 3.0 for test executions and this custom installation step is failing to run.

As a fix, this custom installation step has been removed.