### PR TITLE
Add support for activity_copy_limit for single feed follows

### DIFF
--- a/src/stream-net-tests/IntegrationTests.cs
+++ b/src/stream-net-tests/IntegrationTests.cs
@@ -645,6 +645,60 @@ namespace stream_net_tests
                 Assert.Fail("Initial activity count not zero.");
             }
         }
+        [Test]
+        public async Task TestFlatFollowActivityCopyLimitDefault()
+        {
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed("flat", "333", false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await this._flat3.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed("flat", "333");
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(5, activities.Count());
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
+        [Test]
+        public async Task TestFlatFollowActivityCopyLimitNonDefault()
+        {
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed("flat", "333", false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await this._flat3.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed("flat", "333", 3);
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(3, activities.Count());
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
 
         [Test]
         public async Task TestFlatFollowUnfollowByFeedKeepHistoryDefault()
@@ -749,6 +803,60 @@ namespace stream_net_tests
                 Assert.IsNotNull(activities);
                 Assert.AreEqual(1, activities.Count());
                 Assert.AreEqual(response.Id, activities.First().Id);
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
+        [Test]
+        public async Task TestFlatFollowByFeedActivityCopyLimitDefault()
+        {
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed(_flat3, false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await this._flat3.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed(_flat3);
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(5, activities.Count());
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
+        [Test]
+        public async Task TestFlatFollowByFeedActivityCopyLimitNonDefault()
+        {
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed(_flat3, false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await this._flat3.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed(_flat3, 3);
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(3, activities.Count());
             }
             else
             {
@@ -865,6 +973,64 @@ namespace stream_net_tests
                 Assert.IsNotNull(activities);
                 Assert.AreEqual(1, activities.Count());
                 Assert.AreEqual(response.Id, activities.First().Id);
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
+        [Test]
+        public async Task TestFlatFollowPrivateActivityCopyLimitDefault()
+        {
+            var secret = this._client.Feed("secret", "33");
+
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed("secret", "33", false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await secret.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed("secret", "33");
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(5, activities.Count());
+            }
+            else
+            {
+                Assert.Fail("Initial activity count not zero.");
+            }
+        }
+        [Test]
+        public async Task TestFlatFollowPrivateActivityCopyLimitNonDefault()
+        {
+            var secret = this._client.Feed("secret", "33");
+
+            //This initial unfollow is just to reset any existing follows or actvities, not a part of the test
+            await this._user1.UnfollowFeed("secret", "33", false);
+            Thread.Sleep(FollowDelay);
+            var activities = await this._user1.GetActivities(0, 1);
+
+            if (activities.Count() == 0)
+            {
+                Activity[] newActivities = { new Stream.Activity("1", "test", "1"), new Stream.Activity("1", "test", "2"), new Stream.Activity("1", "test", "3"), new Stream.Activity("1", "test", "4"), new Stream.Activity("1", "test", "5") };
+                var response = await secret.AddActivities(newActivities);
+
+                Thread.Sleep(AddDelay);
+
+                await this._user1.FollowFeed("secret", "33", 3);
+                Thread.Sleep(FollowDelay);
+
+                activities = await this._user1.GetActivities(0, 5);
+                Assert.IsNotNull(activities);
+                Assert.AreEqual(3, activities.Count());
             }
             else
             {

--- a/src/stream-net/BatchOperations.cs
+++ b/src/stream-net/BatchOperations.cs
@@ -9,6 +9,7 @@ namespace Stream
     public class BatchOperations
     {
         private const int CopyLimitDefault = 300;
+        private const int CopyLimitMax = 1000;
 
         readonly StreamClient _client;
 
@@ -38,10 +39,11 @@ namespace Stream
 
         public async Task FollowMany(IEnumerable<Follow> follows, int activityCopyLimit = CopyLimitDefault)
         {
-            var request = _client.BuildAppRequest("follow_many/", RestSharp.Method.POST);
-            if (activityCopyLimit != CopyLimitDefault)
-                request.AddQueryParameter("activity_copy_limit", activityCopyLimit.ToString());
+            if (activityCopyLimit > CopyLimitMax) activityCopyLimit = CopyLimitMax;
 
+            var request = _client.BuildAppRequest("follow_many/", RestSharp.Method.POST);
+
+            request.AddQueryParameter("activity_copy_limit", activityCopyLimit.ToString());
             request.AddJsonBody(from f in follows
                                 select new
                                 {

--- a/src/stream-net/StreamFeed.cs
+++ b/src/stream-net/StreamFeed.cs
@@ -20,6 +20,9 @@ namespace Stream
         readonly string _feedSlug;
         readonly string _userId;
 
+        private const int CopyLimitDefault = 300;
+        private const int CopyLimitMax = 1000;
+
         internal StreamFeed(StreamClient client, string feedSlug, string userId, string token)
         {
             if (!_feedRegex.IsMatch(feedSlug))
@@ -279,17 +282,20 @@ namespace Stream
             return GetWithOptions<NotificationActivity>(options);
         }
 
-        public async Task FollowFeed(StreamFeed feedToFollow)
+        public async Task FollowFeed(StreamFeed feedToFollow, int activityCopyLimit = CopyLimitDefault)
         {
             if (feedToFollow == null)
                 throw new ArgumentNullException("feedToFollow", "Must have a feed to follow");
             if (feedToFollow.FeedTokenId == this.FeedTokenId)
                 throw new ArgumentException("Cannot follow myself");
+            if (activityCopyLimit > CopyLimitMax) activityCopyLimit = CopyLimitMax;
 
-            var request = _client.BuildFeedRequest(this, "/follows/", Method.POST);
+            var request = _client.BuildFeedRequest(this, "/following/", Method.POST);
+
             request.AddJsonBody(new
             {
                 target = feedToFollow.FeedId,
+                activity_copy_limit = activityCopyLimit,
                 target_token = feedToFollow.Token
             });
 
@@ -299,9 +305,9 @@ namespace Stream
                 throw StreamException.FromResponse(response);
         }
 
-        public Task FollowFeed(string targetFeedSlug, string targetUserId)
+        public Task FollowFeed(string targetFeedSlug, string targetUserId, int activityCopyLimit = CopyLimitDefault)
         {
-            return FollowFeed(this._client.Feed(targetFeedSlug, targetUserId));
+            return FollowFeed(this._client.Feed(targetFeedSlug, targetUserId), activityCopyLimit);
         }
 
         public async Task UnfollowFeed(StreamFeed feedToUnfollow, bool keepHistory = false)
@@ -311,7 +317,7 @@ namespace Stream
             if (feedToUnfollow.FeedTokenId == this.FeedTokenId)
                 throw new ArgumentException("Cannot unfollow myself");
 
-            var request = _client.BuildFeedRequest(this, "/follows/" + feedToUnfollow.FeedId + "/", Method.DELETE);
+            var request = _client.BuildFeedRequest(this, "/following/" + feedToUnfollow.FeedId + "/", Method.DELETE);
             request.AddQueryParameter("keep_history", keepHistory.ToString());
 
             var response = await _client.MakeRequest(request);


### PR DESCRIPTION
Includes tests and also adds a check for the activity_copy_limit max.